### PR TITLE
Renamed Khan and Legion stuff back to where it was, redone the flags where it was before.

### DIFF
--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -244,21 +244,27 @@
 		if(do_after(user, 60, target = src))
 			var/obj/item/stack/sheet/leather/H = I
 			if(H.use(1))
-				var/list/choices = list("Bandit", "Outlaw", "BOS", "Followers")
+				var/list/choices = list("NCR", "Legion", "Yuma", "BOS", "Followers", "Bandit", "Outlaw", "Followers", "Great Khans")
 				var/flag = input("Please choose which faction flag you wish to create.") in choices
 				switch(flag)
-					if("Bandit")
-						name = "Bandit flag"
-						desc = "A flag with a skull, maybe it marking where the cemetary is."
-						icon_state = "locustflag"
-						item_state = "locustflag"
-						faction = "Locust"
-					if("Outlaw")
-						name = "Outlaw flag"
-						desc = "A ragged flag with a skull emblazoned on it, commonly used by the local raider gangs."
-						icon_state = "gunnerflag"
-						item_state = "gunnerflag"
-						faction = "Gunner"
+					if(FACTION_NCR)
+						name = "NCR flag"
+						desc = "A flag with a two headed bear, the symbol of the New California Republic."
+						icon_state = "ncrflag"
+						item_state = "ncrflag"
+						faction = "NCR"
+					if(FACTION_LEGION)
+						name = "Legion flag"
+						desc = "A flag with a golden bull, the symbol of Caesar's Legion."
+						icon_state = "legionflag"
+						item_state = "legionflag"
+						faction = FACTION_LEGION
+					if("Yuma")
+						name = "Yuma flag"
+						desc = "A banner depicting three rivers meeting at its center, overlaid with an ear of corn."
+						icon_state = "cornflag"
+						item_state = "cornflag"
+						faction = FACTION_OASIS
 					if(FACTION_BROTHERHOOD)
 						name = "BOS flag"
 						desc = "A red and black flag with a sword surrounded in gears and wings, in a dazzling gold."
@@ -271,6 +277,24 @@
 						icon_state = "followersflag"
 						item_state = "followersflag"
 						faction = FACTION_FOLLOWERS
+					if("Great Khans")
+						name = "Great Khans flag"
+						desc = "A flag worn and weathered from a long cherished history. A decorated smiling skull smiles mockingly upon those who challenge it."
+						icon_state = "khanflag"
+						item_state = "khanflag"
+						faction = "Great Khans"
+					if("Bandit")
+						name = "Bandit flag"
+						desc = "A flag with a skull, maybe it marking where the cemetary is."
+						icon_state = "locustflag"
+						item_state = "locustflag"
+						faction = "Locust"
+					if("Outlaw")
+						name = "Outlaw flag"
+						desc = "A ragged flag with a skull emblazoned on it, commonly used by the local raider gangs."
+						icon_state = "gunnerflag"
+						item_state = "gunnerflag"
+						faction = "Gunner"
 				update_icon()
 	else
 		attack_hand(user)
@@ -299,34 +323,8 @@
 	dropped(thrower)
 
 
-/*   OLDER things that isnt the flags in a way, and how to use them in the upper things.
-				var/list/choices = list("NCR", "Legion", "Yuma", "BOS", "Followers", "Great Khans")
-					if(FACTION_NCR)
-						name = "NCR flag"
-						desc = "A flag with a two headed bear, the symbol of the New California Republic."
-						icon_state = "ncrflag"
-						item_state = "ncrflag"
-						faction = "NCR"
-					if(FACTION_LEGION)
-						name = "Legion flag"
-						desc = "A flag with a golden bull, the symbol of Caesar's Legion."
-						icon_state = "legionflag"
-						item_state = "legionflag"
-						faction = FACTION_LEGION
-					if("Yuma")
-						name = "Yuma flag"
-						desc = "A banner depicting three rivers meeting at its center, overlaid with an ear of corn."
-						icon_state = "cornflag"
-						item_state = "cornflag"
-						faction = FACTION_OASIS
 
-					if("Great Khans")
-						name = "Great Khans flag"
-						desc = "A flag worn and weathered from a long cherished history. A decorated smiling skull smiles mockingly upon those who challenge it."
-						icon_state = "khanflag"
-						item_state = "khanflag"
-						faction = "Great Khans"
-*/
+
 
 ////////Viper stuff////// subject to change, but this way was simple
 /obj/item/viper_venom

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -851,8 +851,8 @@ obj/item/clothing/head/helmet/f13/enclave/usmcriot
 ////////////////////////
 
 /obj/item/clothing/head/helmet/f13/khan
-	name = "horned helmet"
-	desc = "A piece of headwear commonly worn by the horned tribals that appears to resemble stereotypical traditional Mongolian helmets - likely adapted from a pre-War motorcycle helmet.<br>It is black with two horns on either side and a small spike jutting from the top, much like a pickelhaube.<br>A leather covering protects the wearer's neck and ears from sunburn."
+	name = "Great Khan helmet"
+	desc = "A piece of headwear commonly worn by the Great Khans that appears to resemble stereotypical traditional Mongolian helmets - likely adapted from a pre-War motorcycle helmet.<br>It is black with two horns on either side and a small spike jutting from the top, much like a pickelhaube.<br>A leather covering protects the wearer's neck and ears from sunburn."
 	icon = 'icons/fallout/clothing/khans.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/khaans.dmi'
 	icon_state = "khan_helmet"
@@ -869,7 +869,7 @@ obj/item/clothing/head/helmet/f13/enclave/usmcriot
  */
 
 /obj/item/clothing/head/helmet/f13/khan/pelt
-	desc = "A helmet with traditional horns, but wasteland-chique fur trimming instead of the classic leather cover. For the horned tribals who wants to show off their hair."
+	desc = "A helmet with traditional horns, but wasteland-chique fur trimming instead of the classic leather cover. For the Khan who wants to show off their hair."
 	icon_state = "khan_helmetpelt"
 	item_state = "khan_helmetpelt"
 
@@ -879,7 +879,7 @@ obj/item/clothing/head/helmet/f13/enclave/usmcriot
  */
 
 /obj/item/clothing/head/helmet/f13/khan/bandana
-	name = "outlaw bandana"
+	name = "Great Khan bandana"
 	desc = "A bandana. Tougher than it looks. One side of the cloth is dark, the other red, so it can be reversed."
 	icon_state = "khan_bandana"
 	item_state = "khan_bandana"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -418,7 +418,7 @@
 	adjustmask(user)
 
 /////////////////////
-//"LEGION" BANDANAS//
+//LEGION BANDANAS//
 /////////////////////
 
 /obj/item/clothing/mask/bandana/legion
@@ -432,13 +432,13 @@
 	actions_types = list(/datum/action/item_action/adjust)
 
 /obj/item/clothing/mask/bandana/legion/camp
-	name = "desperado bandana"
-	desc = "Simple black cloth normally used by desperados"
+	name = "camp duty bandana"
+	desc = "Simple black cloth intended for men on camp duty."
 	icon_state = "legaux"
 
 /obj/item/clothing/mask/bandana/legion/legrecruit
-	name = "thieves bandana"
-	desc = "A coarse dark thieves bandana."
+	name = "recruit bandana"
+	desc = "A coarse dark recruit bandana."
 	icon_state = "legrecruit"
 
 /obj/item/clothing/mask/bandana/legion/legprime
@@ -447,20 +447,20 @@
 	icon_state = "legdecan"
 
 /obj/item/clothing/mask/bandana/legion/legvet
-	name = "bandito bandana"
-	desc = "A banditos bandana in red."
+	name = "veteran bandana"
+	desc = "A veterans bandana in red."
 	icon_state = "legvet"
 
 /obj/item/clothing/mask/bandana/legion/legdecan
-	name = "outlaw bandana"
-	desc = "A fine bandana in dark red."
+	name = "decanus bandana"
+	desc = "A fine decan bandana in dark red."
 	icon = 'icons/fallout/clothing/masks.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/mask.dmi'
 	icon_state = "legdecan"
 
 /obj/item/clothing/mask/bandana/legion/legcenturion
-	name = "overboss bandana"
-	desc = "A high quality bandana made for a overboss."
+	name = "centurion bandana"
+	desc = "A high quality bandana made for a centurion."
 	icon_state = "legcenturion"
 
 

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -262,21 +262,6 @@
 	path = /obj/item/clothing/head/f13/chinese/officer
 	cost = 2
 
-/datum/gear/head/khan_horned
-	name = "horned helmet"
-	path = /obj/item/clothing/head/helmet/f13/khan
-	cost = 2
-
-/datum/gear/head/khan_furtrimmed
-	name = "horned fur-trimmed helmet"
-	path = /obj/item/clothing/head/helmet/f13/khan/pelt
-	cost = 2
-
-/datum/gear/head/khan_bandana
-	name = "outlaw bandana"
-	path = /obj/item/clothing/head/helmet/f13/khan/bandana
-	cost = 2
-
 //NCR
 
 /datum/gear/head/ncr_sapper
@@ -433,3 +418,19 @@ datum/gear/head/steelpot_bandolier
 							"Secretary",
 							"Shopkeeper",
 						)
+
+/datum/gear/head/khan_bandana
+	name = "Great Khan bandana"
+	path = /obj/item/clothing/head/helmet/f13/khan/bandana
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
+	cost = 2
+	restricted_desc = "KHAN"
+	restricted_roles = list("Great Khan")
+
+/datum/gear/head/khan_furtrimmed
+	name = "Great Khan fur-trimmed helmet"
+	path = /obj/item/clothing/head/helmet/f13/khan/pelt
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
+	cost = 2
+	restricted_desc = "KHAN"
+	restricted_roles = list("Great Khan")

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -105,31 +105,6 @@
 	path = /obj/item/clothing/mask/bandana/skull
 	cost = 1
 
-/datum/gear/mask/bandana/momento
-	name = "momento bandana"
-	path = /obj/item/clothing/mask/bandana/momentobandana
-	cost = 2
-
-/datum/gear/mask/bandana/outlaw
-	name = "outlaw bandana"
-	path = /obj/item/clothing/mask/bandana/legion/legdecan
-	cost = 2
-
-/datum/gear/mask/bandana/bandito 
-	name = "bandito bandana"
-	path = /obj/item/clothing/mask/bandana/legion/legvet
-	cost = 2
-
-/datum/gear/mask/bandana/thieves
-	name = "thieves bandana"
-	path = /obj/item/clothing/mask/bandana/legion/legrecruit
-	cost = 2
-
-/datum/gear/mask/bandana/desperado
-	name = "desperado bandana"
-	path = /obj/item/clothing/mask/bandana/legion/camp
-	cost = 2
-
 /// Misc
 
 /datum/gear/mask/moustache

--- a/modular_citadel/code/modules/client/loadout/shoes.dm
+++ b/modular_citadel/code/modules/client/loadout/shoes.dm
@@ -104,14 +104,6 @@
 	name = "plated war boots"
 	path = /obj/item/clothing/shoes/f13/military/plated
 
-/datum/gear/shoes/military/steeltipped
-	name = "steel tipped boots"
-	path = /obj/item/clothing/shoes/f13/military/khan
-
-/datum/gear/shoes/military/steelpelts
-	name = "steel tipped pelt boots"
-	path = /obj/item/clothing/shoes/f13/military/khan_pelt
-
 /datum/gear/shoes/military/duty
 	name = "duty boots"
 	path = /obj/item/clothing/shoes/f13/military/duty
@@ -148,3 +140,11 @@
 							"NCR Rear Echelon",
 							"NCR Off-Duty"
 						)
+
+/datum/gear/shoes/khan_peltboots
+	name = "Great Khan pelt boots"
+	path = /obj/item/clothing/shoes/f13/military/khan_pelt
+	cost = 2
+	subcategory = LOADOUT_SUBCATEGORY_SHOES_FACTIONS
+	restricted_desc = "KHAN"
+	restricted_roles = list("Great Khan")


### PR DESCRIPTION
## About The Pull Request
Renamed Khan stuff back to khan and rename the legion stuff back to legion. Flags are back where they were and the new outlaw/bandit flags stay on just incase if someone wants to use them.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
revert: Khan + Legion stuff back to where they belong
add: NCR, Legion, Yuma, Khans back so they can be selected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
