### PR TITLE
Rename functionality + Sets possible transfer amounts for small flask

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -11,7 +11,7 @@
  * Pens
  */
 /obj/item/pen
-	desc = "It's a normal black ink pen."
+	desc = "It's a normal black ink pen. Alt-click to change your grip on the pen."
 	name = "pen"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "pen"
@@ -31,6 +31,7 @@
 	var/font = PEN_FONT
 	embedding = list()
 	sharpness = SHARP_POINTY
+	var/naming = FALSE
 
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku..."))
@@ -145,31 +146,51 @@
 	else
 		. = ..()
 
-/obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
-	. = ..()
-	//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
-	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
-		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
-		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
-			return
-		if(penchoice == "Rename")
-			var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
-			var/oldname = O.name
-			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
-				return
-			if(oldname == input)
-				to_chat(user, span_notice("You changed \the [O.name] to... well... \the [O.name]."))
-			else
-				O.name = input
-				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
-				O.renamedByPlayer = TRUE
+/obj/item/pen/AltClick(mob/user)
+	if(!naming)
+		naming = TRUE
+		w_class = WEIGHT_CLASS_GIGANTIC
+		sharpness = SHARP_NONE
+		to_chat(usr, "<span class='notice'>You firmly grip the pen in preparation to rename something.</span>")
+		playsound(src, 'sound/machines/button2.ogg', 100, 1)
+		return
+	if(naming)
+		naming = FALSE
+		w_class = WEIGHT_CLASS_TINY
+		sharpness = SHARP_POINTY
+		to_chat(usr, "<span class='notice'>You reset the grip on the pen</span>")
+		playsound(src, 'sound/machines/button2.ogg', 100, 1)
+		return
 
-		if(penchoice == "Change description")
-			var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+
+/obj/item/pen/afterattack(obj/O, mob/living/user, proximity, params)
+	. = ..()
+	if (naming)
+		//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
+		if(isobj(O) && proximity)
+			var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			O.desc = input
-			to_chat(user, span_notice("You have successfully changed \the [O.name]'s description."))
+			if(penchoice == "Rename")
+				var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
+				var/oldname = O.name
+				if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+					return
+				if(oldname == input)
+					to_chat(user, "<span class='notice'>You changed \the [O.name] to... well... \the [O.name].</span>")
+				else
+					O.name = input
+					to_chat(user, "<span class='notice'>\The [oldname] has been successfully been renamed to \the [input].</span>")
+					O.renamedByPlayer = TRUE
+
+			if(penchoice == "Change description")
+				var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+				if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+					return
+				O.desc = input
+				to_chat(user, "<span class='notice'>You have successfully changed \the [O.name]'s description.</span>")
+	else	
+		return
 
 /*
  * Sleepypens

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -189,6 +189,7 @@
 	desc = "A small flask. It can hold up to 40 units. Unable to withstand reagents of an extreme pH."
 	custom_materials = list(/datum/material/glass = 1000)
 	icon_state = "flasksmall"
+	possible_transfer_amounts = list(5,10,15,20,25,30,40)
 	volume = 40
 
 /obj/item/reagent_containers/glass/beaker/flask/spouty


### PR DESCRIPTION
## About The Pull Request
This PR basically turns into pen renaming with alt click on the pen, which fixes and will make flavor a bunch better plus a feature. Removes unusable transfer amounts for small flasks. Adds a usable amount equal to its volume.


https://github.com/fortune13-ss13/thewasteland/pull/467
https://github.com/fortune13-ss13/thewasteland/pull/779


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: renaming fuctinoality and sets possible transfer amounts for small flask.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
