### PR TITLE
Trim + vault suit into loadout menu

### DIFF
--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -1076,6 +1076,18 @@
 	cost = 1
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
+/// Vault stuff in wasteland tab below 
+
+/datum/gear/uniform/wasteland/vault
+	name = "vault jumpsuit"
+	path = /obj/item/clothing/under/f13/vault
+	cost = 1
+	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
+
+/datum/gear/uniform/wasteland/vault/v13
+	name = "vault 113 jumpsuit"
+	path = /obj/item/clothing/under/f13/vault/v13
+
 /// Tribal stuff in wasteland tab below
 
 /datum/gear/uniform/wasteland/loincloth
@@ -1087,62 +1099,42 @@
 /datum/gear/uniform/wasteland/loincloth/hunter
 	name = "Rugged loincloth outfit"
 	path = /obj/item/clothing/under/f13/wayfarer/hunter
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/exiled
 	name = "Disleveled loincloth"
 	path = /obj/item/clothing/under/f13/exile/tribal
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/rags
 	name = "Tribal Rags outfit"
 	path = /obj/item/clothing/under/f13/tribe
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/razorclaw
 	name = "Razorclaw robes outfit"
 	path = /obj/item/clothing/under/f13/tribe_Hhunter
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/shamanrobes
 	name = "Tribal shaman robes outfit"
 	path = /obj/item/clothing/under/f13/tribe_shaman
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/shamanred
 	name = "Red shaman robes outfit"
 	path = /obj/item/clothing/under/f13/wayfarer/shamanred
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/shamanblue
 	name = "Blue shaman robes outfit"
 	path = /obj/item/clothing/under/f13/wayfarer/shamanblue
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/chiefrobes
 	name = "Tribal chief robes outfit"
 	path = /obj/item/clothing/under/f13/tribe_chief
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/maletribal
 	name = "male tribal outfit"
 	path = /obj/item/clothing/under/f13/tribal
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/loincloth/femaletribal
 	name = "female tribal outfit"
 	path = /obj/item/clothing/under/f13/female/tribal
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/bone/dancer
 	name = "Bone dancer outfit"
@@ -1159,8 +1151,6 @@
 /datum/gear/uniform/wasteland/sorrows/female
 	name = "Sorrows female garb"
 	path = /obj/item/clothing/under/f13/female/sorrows
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/deadhorses
 	name = "Dead horses garb"
@@ -1171,8 +1161,6 @@
 /datum/gear/uniform/wasteland/deadhorses/female
 	name = "Dead horses female garb"
 	path = /obj/item/clothing/under/f13/female/deadhorses
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/rustwalker
 	name = "Rust walkers outfit"
@@ -1183,8 +1171,6 @@
 /datum/gear/uniform/wasteland/rustwalker/female
 	name = "Rust walkers female outfit"
 	path = /obj/item/clothing/under/f13/female/rustwalkers
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/whitelegs
 	name = "White legs outfit"
@@ -1195,5 +1181,4 @@
 /datum/gear/uniform/wasteland/whitelegs/female
 	name = "White legs female outfit"
 	path = /obj/item/clothing/under/f13/female/whitelegs
-	cost = 1
-	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
+


### PR DESCRIPTION
## About The Pull Request
trims uniform tab a bit by removing some cost / catagory with adding two vault suits into the loadout option

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
trims: unfirom tab and adds vault suits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
