### PR TITLE
Wayfarer traditions gone bye bye from wastelander tribal

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1143,7 +1143,7 @@
 	time_per_page = 0
 
 /obj/item/book/granter/trait/tribaltraditions/attack_self(mob/user)
-	var/list/choices = list("Dead Horses traditions","Rustwalkers traditions","Sorrows traditions","Wayfarer traditions","Bone Dancer traditions")
+	var/list/choices = list("Dead Horses traditions","Rustwalkers traditions","Sorrows traditions","Bone Dancer traditions")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -1177,10 +1177,6 @@
 				granted_trait = TRAIT_SORROWS_TRAD
 				crafting_recipe_types = list(/datum/crafting_recipe/tribalwar/sorrows/armour, /datum/crafting_recipe/tribalwar/sorrows/garb, /datum/crafting_recipe/tribalwar/sorrows/femalegarb,
 								/datum/crafting_recipe/tribalwar/sorrows/yaoguaigauntlet)
-			if("Wayfarer traditions")
-				traitname = "Wayfarer traditions"
-				granted_trait = TRAIT_WAYFARER_TRAD
-				crafting_recipe_types = list(/datum/crafting_recipe/tribalwar/lighttribe, /datum/crafting_recipe/tribalwar/heavytribe, /datum/crafting_recipe/warmace)
 			if("Bone Dancer traditions")
 				traitname = "Bone Dancer traditions"
 				granted_trait = TRAIT_BONEDANCER_TRAD


### PR DESCRIPTION
## About The Pull Request
Removal of wayfarer traditions from regular far-eastern tribals

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
removal: wayfarer traditions of tribal traditions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
